### PR TITLE
0.14.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "h11" %}
-{% set version = "0.12.0" %}
+{% set version = "0.14.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042
+  sha256: 8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,18 @@ requirements:
   host:
     - python
     - pip
+    - typing_extensions  # [py<38]
+    - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - h11
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/python-hyper/h11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d
 
 build:
-  noarch: python
+  skip: True  # [py<37]
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   description: |
     h11 is an HTTP/1.1 protocol library written in Python, heavily inspired by
     [hyper-h2](https://hyper-h2.readthedocs.io/en/stable/).
-  doc_url: https://h11.readthedocs.io/en/latest/
+  doc_url: https://h11.readthedocs.io/
   dev_url: https://github.com/python-hyper/h11
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,10 +18,10 @@ requirements:
   host:
     - python
     - pip
-    - typing_extensions  # [py<38]
     - wheel
   run:
     - python
+    - typing_extensions  # [py<38]
 
 test:
   imports:


### PR DESCRIPTION
h11 0.14.0

**Destination channel:** defaults

### Links

- [PKG-3955](https://anaconda.atlassian.net/browse/PKG-3955)
- [Upstream repository](https://github.com/python-hyper/h11)
- Relevant dependency PRs:
  - [PKG-3954](https://anaconda.atlassian.net/browse/PKG-3954)

### Explanation of changes:

- Update to 0.14.0
- Update dependencies
- Linter fixes


[PKG-3955]: https://anaconda.atlassian.net/browse/PKG-3955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-3954]: https://anaconda.atlassian.net/browse/PKG-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ