### PR TITLE
h11 0.16.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "h11" %}
-{% set version = "0.14.0" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1
 
 build:
-  skip: True  # [py<37]
+  skip: true  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -36,7 +36,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: 'A pure-Python HTTP/1.1 protocol library.'
+  summary: A pure-Python HTTP/1.1 protocol library.
   description: |
     h11 is an HTTP/1.1 protocol library written in Python, heavily inspired by
     [hyper-h2](https://hyper-h2.readthedocs.io/en/stable/).


### PR DESCRIPTION
h11 0.16.0

https://github.com/python-hyper/h11/compare/v0.14.0...v0.16.0
https://github.com/python-hyper/h11/tree/v0.16.0